### PR TITLE
Compress intermediate files

### DIFF
--- a/lib/python/tools/io.py
+++ b/lib/python/tools/io.py
@@ -212,7 +212,7 @@ def open_maybe_gzip(filename, mode="r"):
         return SubprocessStream([compressor, "-c", "-d", filename], mode="r")
     elif mode == "w":
         f = open(filename, "w")
-        return SubprocessStream([compressor, "-c"], stdout=f, mode="w")
+        return SubprocessStream([compressor, "-1", "-c"], stdout=f, mode="w")
     else:
         raise ValueError("Unsupported mode for compression: %s" % mode)
 

--- a/mro/atac/stages/processing/align_reads/__init__.py
+++ b/mro/atac/stages/processing/align_reads/__init__.py
@@ -12,6 +12,7 @@ import tenkit.reference
 import martian
 import math
 from tools import ReferenceManager
+from tools import open_maybe_gzip
 
 __MRO__ = """
 stage ALIGN_READS(
@@ -38,7 +39,7 @@ def split(args):
     fastq_tests = [x['read1'] for x in args.chunks]
 
     for fastq_test in fastq_tests:
-        with open(fastq_test) as in_file:
+        with open_maybe_gzip(fastq_test) as in_file:
             reader = tk_fasta.read_generator_fastq(in_file)
             for name, read, qual in itertools.islice(reader, 10):
                 if len(read) < MIN_READ_LENGTH:

--- a/mro/atac/stages/processing/trim_reads/__init__.py
+++ b/mro/atac/stages/processing/trim_reads/__init__.py
@@ -355,12 +355,12 @@ def main(args, outs):
                      read_generator_trim_info(trim_info_r2)))
 
     # open output read file, which will be interleaved
-    read_name = martian.make_path("read{}.fastq.lz4".format(file_number))
+    read_name = martian.make_path("read{}.fastq.gz".format(file_number))
     out_readfiles = [read_name]
     out_read_fastq = open_maybe_gzip(read_name, 'w')
 
     # open trimmed read file, which will be interleaved
-    trim_out_name = martian.make_path("TRIM{}.fastq.lz4".format(file_number))
+    trim_out_name = martian.make_path("TRIM{}.fastq.gz".format(file_number))
     out_trimfiles = [trim_out_name]
     out_trim_fastq = open_maybe_gzip(trim_out_name, 'w')
 
@@ -375,7 +375,7 @@ def main(args, outs):
 
     # open barcode file if there is one
     if have_barcode:
-        bc_name = martian.make_path("BC{}.fastq.lz4".format(file_number))
+        bc_name = martian.make_path("BC{}.fastq.gz".format(file_number))
         out_bc_fastq = open_maybe_gzip(bc_name, 'w')
         out_barcodefiles = [bc_name]
         barcode_read = None
@@ -392,7 +392,7 @@ def main(args, outs):
 
     # open sample_index file if there is one
     if have_sample_index:
-        si_name = martian.make_path("SI{}.fastq.lz4".format(file_number))
+        si_name = martian.make_path("SI{}.fastq.gz".format(file_number))
         out_si_fastq = open_maybe_gzip(si_name, 'w')
         si_in = open_maybe_gzip(chunk['sample_index'], 'r')
         sample_index_read = None
@@ -432,18 +432,18 @@ def main(args, outs):
         if read_num > max_read_num:
             read_num = 1
             file_number += 1
-            read_name = martian.make_path("read{}.fastq.lz4".format(file_number))
+            read_name = martian.make_path("read{}.fastq.gz".format(file_number))
             out_read_fastq.close()
             out_read_fastq = open_maybe_gzip(read_name, 'w')
             out_readfiles.append(read_name)
 
-            trim_out_name = martian.make_path("TRIM{}.fastq.lz4".format(file_number))
+            trim_out_name = martian.make_path("TRIM{}.fastq.gz".format(file_number))
             out_trim_fastq.close()
             out_trim_fastq = open_maybe_gzip(trim_out_name, 'w')
             out_trimfiles.append(trim_out_name)
 
             if have_barcode:
-                bc_name = martian.make_path("BC{}.fastq.lz4".format(file_number))
+                bc_name = martian.make_path("BC{}.fastq.gz".format(file_number))
                 out_bc_fastq.close()
                 out_bc_fastq = open_maybe_gzip(bc_name, 'w')
                 out_barcodefiles.append(bc_name)
@@ -451,7 +451,7 @@ def main(args, outs):
                 out_barcodefiles.append(None)
 
             if have_sample_index:
-                si_name = martian.make_path("SI{}.fastq.lz4".format(file_number))
+                si_name = martian.make_path("SI{}.fastq.gz".format(file_number))
                 out_si_fastq.close()
                 out_si_fastq = open_maybe_gzip(si_name, 'w')
                 out_sampleindex_files.append(si_name)

--- a/mro/atac/stages/processing/trim_reads/__init__.py
+++ b/mro/atac/stages/processing/trim_reads/__init__.py
@@ -311,15 +311,15 @@ def main(args, outs):
     if args.trim_def['discard_untrimmed']:
         martian.exit("discard_untrimmed was set in trim_def")
     if interleaved:
-        trimmed_reads = martian.make_path("trimmed_reads.fastq")
-        trim_info_fn = martian.make_path("trim_info.txt")
+        trimmed_reads = martian.make_path("trimmed_reads.fastq.gz")
+        trim_info_fn = martian.make_path("trim_info.txt.gz")
         initial_read_pairs, trimmed_read_pairs = run_cutadapt_single_end(chunk['read1'], trimmed_reads,
                                                                          trim_info_fn, args.trim_def, args.adapters)
     else:
-        trimmed_r1 = martian.make_path("trimmed_r1.fastq")
-        trimmed_r2 = martian.make_path("trimmed_r2.fastq")
-        trim_info_r1_fn = martian.make_path("trim_info_r1.txt")
-        trim_info_r2_fn = martian.make_path("trim_info_r2.txt")
+        trimmed_r1 = martian.make_path("trimmed_r1.fastq.gz")
+        trimmed_r2 = martian.make_path("trimmed_r2.fastq.gz")
+        trim_info_r1_fn = martian.make_path("trim_info_r1.txt.gz")
+        trim_info_r2_fn = martian.make_path("trim_info_r2.txt.gz")
         initial1, trimmed1 = run_cutadapt_single_end(chunk['read1'], trimmed_r1,
                                                      trim_info_r1_fn, args.trim_def, args.adapters, read_id="R1")
         initial2, trimmed2 = run_cutadapt_single_end(chunk['read2'], trimmed_r2,
@@ -355,14 +355,14 @@ def main(args, outs):
                      read_generator_trim_info(trim_info_r2)))
 
     # open output read file, which will be interleaved
-    read_name = martian.make_path("read{}.fastq".format(file_number))
+    read_name = martian.make_path("read{}.fastq.gz".format(file_number))
     out_readfiles = [read_name]
-    out_read_fastq = open(read_name, 'w')
+    out_read_fastq = open_maybe_gzip(read_name, 'w')
 
     # open trimmed read file, which will be interleaved
-    trim_out_name = martian.make_path("TRIM{}.fastq".format(file_number))
+    trim_out_name = martian.make_path("TRIM{}.fastq.gz".format(file_number))
     out_trimfiles = [trim_out_name]
-    out_trim_fastq = open(trim_out_name, 'w')
+    out_trim_fastq = open_maybe_gzip(trim_out_name, 'w')
 
     if args.barcode_whitelist is None:
         outs.bc_counts = None
@@ -375,8 +375,8 @@ def main(args, outs):
 
     # open barcode file if there is one
     if have_barcode:
-        bc_name = martian.make_path("BC{}.fastq".format(file_number))
-        out_bc_fastq = open(bc_name, 'w')
+        bc_name = martian.make_path("BC{}.fastq.gz".format(file_number))
+        out_bc_fastq = open_maybe_gzip(bc_name, 'w')
         out_barcodefiles = [bc_name]
         barcode_read = None
         bc_in = open_maybe_gzip(chunk['barcode'], 'r')
@@ -392,8 +392,8 @@ def main(args, outs):
 
     # open sample_index file if there is one
     if have_sample_index:
-        si_name = martian.make_path("SI{}.fastq".format(file_number))
-        out_si_fastq = open(si_name, 'w')
+        si_name = martian.make_path("SI{}.fastq.gz".format(file_number))
+        out_si_fastq = open_maybe_gzip(si_name, 'w')
         si_in = open_maybe_gzip(chunk['sample_index'], 'r')
         sample_index_read = None
         si_iter = tk_fasta.read_generator_fastq(si_in)
@@ -432,28 +432,28 @@ def main(args, outs):
         if read_num > max_read_num:
             read_num = 1
             file_number += 1
-            read_name = martian.make_path("read{}.fastq".format(file_number))
+            read_name = martian.make_path("read{}.fastq.gz".format(file_number))
             out_read_fastq.close()
-            out_read_fastq = open(read_name, 'w')
+            out_read_fastq = open_maybe_gzip(read_name, 'w')
             out_readfiles.append(read_name)
 
-            trim_out_name = martian.make_path("TRIM{}.fastq".format(file_number))
+            trim_out_name = martian.make_path("TRIM{}.fastq.gz".format(file_number))
             out_trim_fastq.close()
-            out_trim_fastq = open(trim_out_name, 'w')
+            out_trim_fastq = open_maybe_gzip(trim_out_name, 'w')
             out_trimfiles.append(trim_out_name)
 
             if have_barcode:
-                bc_name = martian.make_path("BC{}.fastq".format(file_number))
+                bc_name = martian.make_path("BC{}.fastq.gz".format(file_number))
                 out_bc_fastq.close()
-                out_bc_fastq = open(bc_name, 'w')
+                out_bc_fastq = open_maybe_gzip(bc_name, 'w')
                 out_barcodefiles.append(bc_name)
             else:
                 out_barcodefiles.append(None)
 
             if have_sample_index:
-                si_name = martian.make_path("SI{}.fastq".format(file_number))
+                si_name = martian.make_path("SI{}.fastq.gz".format(file_number))
                 out_si_fastq.close()
-                out_si_fastq = open(si_name, 'w')
+                out_si_fastq = open_maybe_gzip(si_name, 'w')
                 out_sampleindex_files.append(si_name)
             else:
                 out_sampleindex_files.append(None)

--- a/mro/atac/stages/processing/trim_reads/__init__.py
+++ b/mro/atac/stages/processing/trim_reads/__init__.py
@@ -355,12 +355,12 @@ def main(args, outs):
                      read_generator_trim_info(trim_info_r2)))
 
     # open output read file, which will be interleaved
-    read_name = martian.make_path("read{}.fastq.gz".format(file_number))
+    read_name = martian.make_path("read{}.fastq.lz4".format(file_number))
     out_readfiles = [read_name]
     out_read_fastq = open_maybe_gzip(read_name, 'w')
 
     # open trimmed read file, which will be interleaved
-    trim_out_name = martian.make_path("TRIM{}.fastq.gz".format(file_number))
+    trim_out_name = martian.make_path("TRIM{}.fastq.lz4".format(file_number))
     out_trimfiles = [trim_out_name]
     out_trim_fastq = open_maybe_gzip(trim_out_name, 'w')
 
@@ -375,7 +375,7 @@ def main(args, outs):
 
     # open barcode file if there is one
     if have_barcode:
-        bc_name = martian.make_path("BC{}.fastq.gz".format(file_number))
+        bc_name = martian.make_path("BC{}.fastq.lz4".format(file_number))
         out_bc_fastq = open_maybe_gzip(bc_name, 'w')
         out_barcodefiles = [bc_name]
         barcode_read = None
@@ -392,7 +392,7 @@ def main(args, outs):
 
     # open sample_index file if there is one
     if have_sample_index:
-        si_name = martian.make_path("SI{}.fastq.gz".format(file_number))
+        si_name = martian.make_path("SI{}.fastq.lz4".format(file_number))
         out_si_fastq = open_maybe_gzip(si_name, 'w')
         si_in = open_maybe_gzip(chunk['sample_index'], 'r')
         sample_index_read = None
@@ -432,18 +432,18 @@ def main(args, outs):
         if read_num > max_read_num:
             read_num = 1
             file_number += 1
-            read_name = martian.make_path("read{}.fastq.gz".format(file_number))
+            read_name = martian.make_path("read{}.fastq.lz4".format(file_number))
             out_read_fastq.close()
             out_read_fastq = open_maybe_gzip(read_name, 'w')
             out_readfiles.append(read_name)
 
-            trim_out_name = martian.make_path("TRIM{}.fastq.gz".format(file_number))
+            trim_out_name = martian.make_path("TRIM{}.fastq.lz4".format(file_number))
             out_trim_fastq.close()
             out_trim_fastq = open_maybe_gzip(trim_out_name, 'w')
             out_trimfiles.append(trim_out_name)
 
             if have_barcode:
-                bc_name = martian.make_path("BC{}.fastq.gz".format(file_number))
+                bc_name = martian.make_path("BC{}.fastq.lz4".format(file_number))
                 out_bc_fastq.close()
                 out_bc_fastq = open_maybe_gzip(bc_name, 'w')
                 out_barcodefiles.append(bc_name)
@@ -451,7 +451,7 @@ def main(args, outs):
                 out_barcodefiles.append(None)
 
             if have_sample_index:
-                si_name = martian.make_path("SI{}.fastq.gz".format(file_number))
+                si_name = martian.make_path("SI{}.fastq.lz4".format(file_number))
                 out_si_fastq.close()
                 out_si_fastq = open_maybe_gzip(si_name, 'w')
                 out_sampleindex_files.append(si_name)

--- a/tenkit/lib/python/tenkit/align.py
+++ b/tenkit/lib/python/tenkit/align.py
@@ -58,9 +58,9 @@ def bwa_align_unpaired(ref_fasta, read_fastq, out_name, algorithm='ALN', max_hit
 
     if algorithm == 'MEM':
         # Temp file names
-        sam_name = out_name + '.sam'
+        sam_name = out_name + '.sam.gz'
 
-        sam_out_file = open(sam_name, 'w')
+        sam_out_file = open_maybe_gzip(sam_name, 'w')
         log_subprocess.check_call(['bwa', 'mem', '-t', str(num_threads), '-M', '-R', read_group_header, ref_fasta, read_fastq], stdout=sam_out_file)
         sam_out_file.close()
 


### PR DESCRIPTION
The `cellranger-atac count` TRIM_READS and ALIGN_READS stages currently write intermediate uncompressed FASTQ and SAM files, respectively. Unless the target file system is transparently compressed (e.g., a ZFS file system with compression enabled), intermediate data storage requirements can be well above the input data size.

This PR is a lightly-tested work in progress that modifies the cutadapt command to [write compressed files](https://cutadapt.readthedocs.io/en/stable/guide.html#compressed-files), and subsequently uses the existing tenkit `open_maybe_gzip()` routine (using `gzip -1` compression to avoid inflating runtime) to handle the resulting compressed files, as well as to compress the SAM output of `bwa mem`.

It woudl be beneficial to have something like this in a future release of cellranger-atac to reduce intermediate data storage needed for processing with `cellranger-atac count` (note that I briefly tried lz4 compression, but encountered some error. I didn't attempt to troubleshoot, and reverted to gzip, but lz4 might be worth investigating for some intermediate files after cutadapt processing to further reduce CPU requirements).